### PR TITLE
Implement optimization for Android with R8

### DIFF
--- a/sweetspi-runtime/src/jvmMain/kotlin/InternalServiceLoader.jvm.kt
+++ b/sweetspi-runtime/src/jvmMain/kotlin/InternalServiceLoader.jvm.kt
@@ -9,7 +9,17 @@ import java.util.*
 @JvmField
 @InternalSweetSpiApi
 internal actual val internalServiceLoader: Lazy<InternalServiceLoader> = lazy {
-    InternalServiceLoader(ServiceLoader.load(InternalServiceModule::class.java).toList())
+    val modules = Iterable {
+        // ServiceLoader should use specific call convention to be optimized by R8 on Android:
+        // `ServiceLoader.load(X.class, X.class.getClassLoader()).iterator()`
+        // source:
+        // https://r8.googlesource.com/r8/+/refs/heads/main/src/main/java/com/android/tools/r8/ir/optimize/ServiceLoaderRewriter.java
+        ServiceLoader.load(
+            InternalServiceModule::class.java,
+            InternalServiceModule::class.java.classLoader
+        ).iterator()
+    }.toList()
+    InternalServiceLoader(modules)
 }
 
 // IDEA shows an error because of a wrong visibility inspection


### PR DESCRIPTION
Fixes #1

Tested with Android Studio on emulators with API 35 (Android 15) and API 23 (Android 6.0) with the following config:
```
debug {
    isDebuggable = false
    isMinifyEnabled = true
    proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
}
```

At my side with call to `ServiceLoader.load<TestService>` in `MainActivity` just after `super.onCreate(savedInstanceState)` with three implementations takes around:
* 10-20 millis with `isMinifyEnabled=false` on 0.1.0
* 10-20 millis with `isMinifyEnabled=true` on 0.1.0
* 10-20 millis with `isMinifyEnabled=false` on this PR
* 300-500 nanoseconds with `isMinifyEnabled=true` on this PR

I get the same 300-500 nanoseconds with `isMinifyEnabled=true` if I will just repeat the same machinery in the app, as I use under the hood to aggregate services, when just passing `objects`.
I get 100-200 nanoseconds with `isMinifyEnabled=true` if to remove the machinery and just use `java.util.ServiceLoader.load`.

Yeah, there is some overhead, but I would say it's rather minimal. Of course the situation on real devices will be different, but it will be different even with manual initialization.

So, looks like in the end currently `ServiceLoader` on Android is not really slow. Except for the case when the `Service` is in base module, but `ServiceProvider` is in the [feature module](https://developer.android.com/guide/playcore/feature-delivery).