### PR TITLE
Include Java ServiceLoader services in loaded services

### DIFF
--- a/sweetspi-runtime/src/commonMain/kotlin/InternalServiceLoader.kt
+++ b/sweetspi-runtime/src/commonMain/kotlin/InternalServiceLoader.kt
@@ -49,7 +49,9 @@ internal class InternalServiceLoader(
 
         @Suppress("UNCHECKED_CAST")
         return synchronized(this) {
-            providers.getOrPut(cls) { modules.flatMap { it.providers(cls) } } as List<T>
+            providers.getOrPut(cls) { modules.flatMap { it.providers(cls) } } as List<T> + loadPlatformServices(cls)
         }
     }
 }
+
+internal expect fun <T : Any> loadPlatformServices(service: KClass<out T>): List<T>

--- a/sweetspi-runtime/src/commonMain/kotlin/ServiceLoader.kt
+++ b/sweetspi-runtime/src/commonMain/kotlin/ServiceLoader.kt
@@ -63,6 +63,8 @@ public annotation class ServiceProvider(
  * - interfaces or abstract classes annotated with [Service] can be retrieved using this loader.
  * - implementations of these services are identified using the [ServiceProvider] annotation.
  *
+ * On JVM platforms, service providers available through `java.util.ServiceLoader` will also be included.
+ *
  * Usage:
  * ```
  * // module: A

--- a/sweetspi-runtime/src/jvmMain/kotlin/InternalServiceLoader.jvm.kt
+++ b/sweetspi-runtime/src/jvmMain/kotlin/InternalServiceLoader.jvm.kt
@@ -5,6 +5,7 @@
 package dev.whyoleg.sweetspi.internal
 
 import java.util.*
+import kotlin.reflect.*
 
 @JvmField
 @InternalSweetSpiApi
@@ -26,3 +27,7 @@ internal actual val internalServiceLoader: Lazy<InternalServiceLoader> = lazy {
 internal actual typealias SynchronizedObject = Any
 
 internal actual inline fun <T> synchronized(lock: SynchronizedObject, block: () -> T): T = kotlin.synchronized(lock, block)
+
+@OptIn(InternalSweetSpiApi::class)
+internal actual fun <T : Any> loadPlatformServices(service: KClass<out T>): List<T> =
+    Iterable { ServiceLoader.load(service.java, service.java.classLoader).iterator() }.toList()

--- a/sweetspi-runtime/src/nonJvmMain/kotlin/InternalServiceLoader.nonJvm.kt
+++ b/sweetspi-runtime/src/nonJvmMain/kotlin/InternalServiceLoader.nonJvm.kt
@@ -4,6 +4,8 @@
 
 package dev.whyoleg.sweetspi.internal
 
+import kotlin.reflect.*
+
 @InternalSweetSpiApi
 private val modules = mutableListOf<InternalServiceModule>()
 
@@ -15,3 +17,5 @@ public fun registerInternalServiceModule(module: InternalServiceModule) {
     check(!internalServiceLoader.isInitialized()) { "ServiceLoader was already initialized, no more modules can be registered" }
     modules += module
 }
+
+internal actual fun <T : Any> loadPlatformServices(service: KClass<out T>): List<T> = emptyList()

--- a/sweetspi-tests/src/test/kotlin/runtime/JvmRuntimeTest.kt
+++ b/sweetspi-tests/src/test/kotlin/runtime/JvmRuntimeTest.kt
@@ -42,4 +42,42 @@ class JvmRuntimeTest : AbstractTest() {
             assert(task(":test")!!.outcome.isPositive)
         }
     }
+
+    @FastVersionedTest
+    fun testJvmServicesAreIncluded(versions: TestVersions) {
+        val project = project(versions) {
+            withSweetSpi()
+            kotlinJvmTest()
+            file("src/$MAIN/resources/META-INF/services/sweettests.multiplatform.SimpleService") {
+                "sweettests.multiplatform.SimpleServiceImpl2"
+            }
+            kotlinSourceFile(
+                sourceSet = MAIN, path = "main.kt",
+                code = """
+                @Service interface SimpleService
+                @ServiceProvider object SimpleServiceImpl : SimpleService
+                class SimpleServiceImpl2 : SimpleService
+                """.trimIndent()
+            )
+            kotlinSourceFile(
+                sourceSet = TEST, path = "test.kt",
+                code = """
+                import kotlin.test.*
+                
+                class SimpleTest {
+                    @Test
+                    fun doTest() {
+                        val services = ServiceLoader.load<SimpleService>()
+                        assertEquals(2, services.size)
+                        assertEquals(SimpleServiceImpl, services[0])
+                        assertEquals(SimpleServiceImpl2::class, services[1]::class)
+                    }
+                }
+                """.trimIndent()
+            )
+        }
+        project.gradle("build") {
+            assert(task(":test")!!.outcome.isPositive)
+        }
+    }
 }


### PR DESCRIPTION
Part of https://github.com/whyoleg/sweet-spi/issues/7

This includes any services from `java.util.ServiceLoader` in the list of loaded services on JVM.