### PR TITLE
Always-dynamic lookups

### DIFF
--- a/sweetspi-runtime/src/commonMain/kotlin/InternalServiceLoader.kt
+++ b/sweetspi-runtime/src/commonMain/kotlin/InternalServiceLoader.kt
@@ -19,37 +19,31 @@ public interface InternalServiceModule {
     public fun providers(cls: KClass<*>): List<*>
 }
 
-@InternalSweetSpiApi
-internal expect val internalServiceLoader: Lazy<InternalServiceLoader>
-
 internal expect open class SynchronizedObject()
 
 internal expect inline fun <T> synchronized(lock: SynchronizedObject, block: () -> T): T
 
 @InternalSweetSpiApi
-internal class InternalServiceLoader(
-    private val modules: List<InternalServiceModule>,
-) : SynchronizedObject() {
-    private val registeredServices: Set<KClass<*>> = modules.flatMapTo(mutableSetOf(), InternalServiceModule::services)
-    private val providers = mutableMapOf<KClass<*>, List<*>>()
+internal expect fun getAvailableModules(): List<InternalServiceModule>
 
-    init {
-        // this could happen mostly if there is something wrong with KSP or runtime code
-        modules.forEach { module ->
-            module.requiredServices.forEach { required ->
-                if (required !in registeredServices) {
-                    println("Service `${required.simpleName}` wasn't registered, required by: $module")
-                }
-            }
-        }
+@InternalSweetSpiApi
+internal object InternalServiceLoader : SynchronizedObject() {
+    private val providerCache = mutableMapOf<Pair<KClass<out InternalServiceModule>, KClass<*>>, List<*>>()
+
+    internal fun <T : Any> getProviders(module: InternalServiceModule, service: KClass<T>, reload: Boolean = false): List<T> {
+        val original = if (reload) null else providerCache[module::class to service]
+        @Suppress("UNCHECKED_CAST") val value = (original ?: module.providers(service)) as List<T>
+        providerCache[module::class to service] = value
+        return value
     }
 
-    fun <T : Any> load(cls: KClass<T>): List<T> {
-        require(cls in registeredServices) { "Service `${cls.simpleName}` wasn't registered" }
+    fun <T : Any> load(cls: KClass<T>, reloadProviders: Boolean = false): List<T> {
+        return load(getAvailableModules(), cls, reloadProviders)
+    }
 
-        @Suppress("UNCHECKED_CAST")
+    fun <T : Any> load(modules: List<InternalServiceModule>, cls: KClass<T>, reloadProviders: Boolean = false): List<T> {
         return synchronized(this) {
-            providers.getOrPut(cls) { modules.flatMap { it.providers(cls) } } as List<T>
+            modules.flatMap { getProviders(it, cls, reloadProviders) }
         }
     }
 }

--- a/sweetspi-runtime/src/commonMain/kotlin/ServiceLoader.kt
+++ b/sweetspi-runtime/src/commonMain/kotlin/ServiceLoader.kt
@@ -94,11 +94,11 @@ public object ServiceLoader {
      */
     @JvmStatic
     @OptIn(InternalSweetSpiApi::class)
-    public fun <T : Any> load(cls: KClass<T>): List<T> = internalServiceLoader.value.load(cls)
+    public fun <T : Any> load(cls: KClass<T>, reloadProviders: Boolean = false): List<T> = InternalServiceLoader.load(cls, reloadProviders)
 
     /**
      * Retrieves a list of services of the specified type [T], which must be annotated with [Service].
      * Providers of these services must be annotated with [ServiceProvider].
      */
-    public inline fun <reified T : Any> load(): List<T> = load(T::class)
+    public inline fun <reified T : Any> load(reloadProviders: Boolean = false): List<T> = load(T::class, reloadProviders)
 }

--- a/sweetspi-runtime/src/jvmMain/kotlin/InternalServiceLoader.jvm.kt
+++ b/sweetspi-runtime/src/jvmMain/kotlin/InternalServiceLoader.jvm.kt
@@ -5,24 +5,34 @@
 package dev.whyoleg.sweetspi.internal
 
 import java.util.*
-
-@JvmField
-@InternalSweetSpiApi
-internal actual val internalServiceLoader: Lazy<InternalServiceLoader> = lazy {
-    val modules = Iterable {
-        // ServiceLoader should use specific call convention to be optimized by R8 on Android:
-        // `ServiceLoader.load(X.class, X.class.getClassLoader()).iterator()`
-        // source:
-        // https://r8.googlesource.com/r8/+/refs/heads/main/src/main/java/com/android/tools/r8/ir/optimize/ServiceLoaderRewriter.java
-        ServiceLoader.load(
-            InternalServiceModule::class.java,
-            InternalServiceModule::class.java.classLoader
-        ).iterator()
-    }.toList()
-    InternalServiceLoader(modules)
-}
+import kotlin.reflect.*
 
 // IDEA shows an error because of a wrong visibility inspection
 internal actual typealias SynchronizedObject = Any
 
 internal actual inline fun <T> synchronized(lock: SynchronizedObject, block: () -> T): T = kotlin.synchronized(lock, block)
+
+@InternalSweetSpiApi
+internal actual fun getAvailableModules(): List<InternalServiceModule> = Iterable {
+    // ServiceLoader should use specific call convention to be optimized by R8 on Android:
+    // `ServiceLoader.load(X.class, X.class.getClassLoader()).iterator()`
+    // source:
+    // https://r8.googlesource.com/r8/+/refs/heads/main/src/main/java/com/android/tools/r8/ir/optimize/ServiceLoaderRewriter.java
+    ServiceLoader.load(
+        InternalServiceModule::class.java,
+        InternalServiceModule::class.java.classLoader
+    ).iterator()
+}.toList()
+
+@InternalSweetSpiApi
+internal fun getAvailableModules(classLoader: ClassLoader): List<InternalServiceModule> = Iterable {
+    ServiceLoader.load(
+        InternalServiceModule::class.java,
+        classLoader
+    ).iterator()
+}.toList()
+
+@InternalSweetSpiApi
+internal fun <T : Any> InternalServiceLoader.load(cls: KClass<T>, classLoader: ClassLoader, reloadProviders: Boolean = false): List<T> {
+    return load(getAvailableModules(classLoader), cls, reloadProviders)
+}

--- a/sweetspi-runtime/src/jvmMain/kotlin/ServiceLoader.jvm.kt
+++ b/sweetspi-runtime/src/jvmMain/kotlin/ServiceLoader.jvm.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Oleg Yukhnevich. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package dev.whyoleg.sweetspi.internal
+
+import dev.whyoleg.sweetspi.*
+import kotlin.reflect.*
+
+
+/**
+ * Retrieves a list of services of the specified type [T], which must be annotated with [Service].
+ * Providers of these services must be annotated with [ServiceProvider].
+ */
+@OptIn(InternalSweetSpiApi::class)
+public fun <T : Any> ServiceLoader.load(cls: KClass<T>, classLoader: ClassLoader, reloadProviders: Boolean = false): List<T> =
+    InternalServiceLoader.load(cls, classLoader, reloadProviders)
+
+/**
+ * Retrieves a list of services of the specified type [T], which must be annotated with [Service].
+ * Providers of these services must be annotated with [ServiceProvider].
+ */
+public inline fun <reified T : Any> ServiceLoader.load(classLoader: ClassLoader, reloadProviders: Boolean = false): List<T> =
+    load(T::class, classLoader, reloadProviders)

--- a/sweetspi-runtime/src/nonJvmMain/kotlin/InternalServiceLoader.nonJvm.kt
+++ b/sweetspi-runtime/src/nonJvmMain/kotlin/InternalServiceLoader.nonJvm.kt
@@ -8,10 +8,9 @@ package dev.whyoleg.sweetspi.internal
 private val modules = mutableListOf<InternalServiceModule>()
 
 @InternalSweetSpiApi
-internal actual val internalServiceLoader: Lazy<InternalServiceLoader> = lazy { InternalServiceLoader(modules) }
-
-@InternalSweetSpiApi
 public fun registerInternalServiceModule(module: InternalServiceModule) {
-    check(!internalServiceLoader.isInitialized()) { "ServiceLoader was already initialized, no more modules can be registered" }
     modules += module
 }
+
+@InternalSweetSpiApi
+internal actual fun getAvailableModules(): List<InternalServiceModule> = modules


### PR DESCRIPTION
Changes the service lookup implementation to not require modules be registered at startup and limits service provider caching. This allows for truly dynamic service loading in open-world platforms like the JVM.